### PR TITLE
Use Symbol line numbers to detect long functions

### DIFF
--- a/src/smart_refactoring.rs
+++ b/src/smart_refactoring.rs
@@ -718,7 +718,7 @@ impl SmartRefactoringEngine {
             // Detect long methods
             for symbol in &file.symbols {
                 if symbol.kind == "function" {
-                    let estimated_length = 50; // Simplified - would need actual line counting
+                    let estimated_length = symbol.end_line.saturating_sub(symbol.start_line) + 1;
 
                     if estimated_length > 30 {
                         fixes.push(CodeSmellFix {


### PR DESCRIPTION
## Summary
- compute each function's length from `Symbol` start and end lines
- use the calculated length for performance hotspot detection
- use the calculated length when detecting long methods in smart refactoring

## Testing
- `cargo test --workspace -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6849f360a4e08324b8979dc123e63d22