### PR TITLE
Add GitHub vulnerability API and caching tests

### DIFF
--- a/src/infrastructure/database.rs
+++ b/src/infrastructure/database.rs
@@ -108,7 +108,7 @@ impl DatabaseManager {
                 description TEXT NOT NULL,
                 published_date TEXT NOT NULL,
                 last_modified TEXT NOT NULL,
-                references TEXT NOT NULL,
+                "references" TEXT NOT NULL,
                 cwe_ids TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL
@@ -211,8 +211,8 @@ impl DatabaseManager {
     pub async fn store_vulnerability(&self, vuln: &VulnerabilityRecord) -> Result<(), sqlx::Error> {
         sqlx::query(r#"
             INSERT OR REPLACE INTO vulnerabilities 
-            (id, cve_id, package_name, affected_versions, severity, cvss_score, description, 
-             published_date, last_modified, references, cwe_ids, created_at, updated_at)
+            (id, cve_id, package_name, affected_versions, severity, cvss_score, description,
+             published_date, last_modified, "references", cwe_ids, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#)
         .bind(&vuln.id)

--- a/src/security/vulnerability_db.rs
+++ b/src/security/vulnerability_db.rs
@@ -284,6 +284,27 @@ pub struct OsvReference {
     pub url: String,
 }
 
+/// GitHub Security Advisory API response structure
+#[derive(Debug, Deserialize)]
+pub struct GitHubResponse {
+    pub advisories: Vec<GitHubAdvisory>,
+}
+
+/// GitHub advisory structure
+#[derive(Debug, Deserialize)]
+pub struct GitHubAdvisory {
+    pub ghsa_id: String,
+    pub cve_id: Option<String>,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub severity: Option<String>,
+    pub cvss_score: Option<f64>,
+    pub references: Option<Vec<String>>,
+    pub cwes: Option<Vec<String>>,
+    pub published_at: String,
+    pub updated_at: String,
+}
+
 impl VulnerabilityDatabase {
     /// Create a new vulnerability database client
     pub async fn new(
@@ -353,6 +374,16 @@ impl VulnerabilityDatabase {
                     vulnerabilities.extend(nvd_vulns);
                 }
                 Err(e) => warn!("NVD API query failed for {}: {}", package_name, e),
+            }
+        }
+
+        if self.github_config.enabled {
+            match self.query_github_api(package_name, ecosystem).await {
+                Ok(gh_vulns) => {
+                    info!("Found {} vulnerabilities from GitHub for {}", gh_vulns.len(), package_name);
+                    vulnerabilities.extend(gh_vulns);
+                }
+                Err(e) => warn!("GitHub API query failed for {}: {}", package_name, e),
             }
         }
 
@@ -428,6 +459,32 @@ impl VulnerabilityDatabase {
         for nvd_vuln in nvd_response.vulnerabilities {
             let vuln_record = self.convert_nvd_to_record(nvd_vuln, package_name)?;
             vulnerabilities.push(vuln_record);
+        }
+
+        Ok(vulnerabilities)
+    }
+
+    /// Query GitHub Security Advisory API for vulnerabilities
+    async fn query_github_api(
+        &self,
+        package_name: &str,
+        ecosystem: &str,
+    ) -> Result<Vec<VulnerabilityRecord>> {
+        self.rate_limiter.wait_for_permit("github").await?;
+
+        let mut config = RequestConfig::default();
+        if let Some(token) = &self.github_config.token {
+            config.auth = Some(AuthConfig::Bearer(token.clone()));
+        }
+
+        let url = format!("{}/advisories?package={}&ecosystem={}", self.github_config.base_url, package_name, ecosystem);
+        let response = self.http_client.get(&url, Some(config)).await?;
+
+        let gh_response: GitHubResponse = serde_json::from_str(&response.body)?;
+        let mut vulnerabilities = Vec::new();
+        for adv in gh_response.advisories {
+            let rec = self.convert_github_to_record(adv, package_name)?;
+            vulnerabilities.push(rec);
         }
 
         Ok(vulnerabilities)
@@ -524,6 +581,36 @@ impl VulnerabilityDatabase {
             severity,
             cvss_score,
             description,
+            published_date,
+            last_modified,
+            references: serde_json::to_string(&references)?,
+            cwe_ids: serde_json::to_string(&cwe_ids)?,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    /// Convert GitHub advisory to VulnerabilityRecord
+    fn convert_github_to_record(&self, adv: GitHubAdvisory, package_name: &str) -> Result<VulnerabilityRecord> {
+        let now = Utc::now();
+        let published_date = DateTime::parse_from_rfc3339(&adv.published_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or(now);
+        let last_modified = DateTime::parse_from_rfc3339(&adv.updated_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or(now);
+
+        let references = adv.references.unwrap_or_default();
+        let cwe_ids = adv.cwes.unwrap_or_default();
+
+        Ok(VulnerabilityRecord {
+            id: Uuid::new_v4().to_string(),
+            cve_id: adv.cve_id.unwrap_or(adv.ghsa_id),
+            package_name: package_name.to_string(),
+            affected_versions: "Unknown".to_string(),
+            severity: adv.severity.unwrap_or_else(|| "UNKNOWN".to_string()),
+            cvss_score: adv.cvss_score,
+            description: adv.summary.unwrap_or_else(|| "No description available".to_string()),
             published_date,
             last_modified,
             references: serde_json::to_string(&references)?,

--- a/tests/security_vuln_db.rs
+++ b/tests/security_vuln_db.rs
@@ -1,0 +1,117 @@
+use rust_tree_sitter::security::vulnerability_db::{VulnerabilityDatabase, NvdConfig, OsvConfig, GitHubConfig};
+use rust_tree_sitter::infrastructure::{DatabaseConfig, DatabaseManager, CacheConfig, Cache};
+use rust_tree_sitter::infrastructure::rate_limiter::RateLimiterFactory;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{method, path};
+use tempfile::NamedTempFile;
+use anyhow::Result;
+
+#[tokio::test]
+async fn test_vulnerability_database_end_to_end() -> Result<()> {
+    // Mock OSV API
+    let osv_server = MockServer::start().await;
+    let osv_body = serde_json::json!({
+        "vulns": [{
+            "id": "CVE-2023-11111",
+            "summary": "OSV vuln",
+            "details": "details",
+            "aliases": ["CVE-2023-11111"],
+            "modified": "2024-01-01T00:00:00Z",
+            "published": "2023-12-31T00:00:00Z",
+            "severity": [{"type": "CVSS_V3", "score": "9.8"}],
+            "affected": null,
+            "references": [{"type": "ADVISORY", "url": "http://example.com/osv"}]
+        }]
+    });
+    Mock::given(method("POST")).and(path("/v1/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(osv_body))
+        .mount(&osv_server)
+        .await;
+
+    // Mock NVD API
+    let nvd_server = MockServer::start().await;
+    let nvd_body = serde_json::json!({
+        "vulnerabilities": [{"cve": {
+            "id": "CVE-2023-11111",
+            "sourceIdentifier": "nvd",
+            "published": "2023-12-30T00:00:00Z",
+            "lastModified": "2024-01-01T00:00:00Z",
+            "descriptions": [{"lang": "en", "value": "NVD desc"}],
+            "metrics": {"cvssMetricV31": [{"source": "nvd", "type": "Primary", "cvssData": {"version": "3.1", "vectorString": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "baseScore": 9.8, "baseSeverity": "CRITICAL"}}]},
+            "references": [{"url": "http://example.com/nvd"}]
+        }}],
+        "totalResults": 1,
+        "resultsPerPage": 1,
+        "startIndex": 0
+    });
+    Mock::given(method("GET")).and(path("/cves/2.0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(nvd_body))
+        .mount(&nvd_server)
+        .await;
+
+    // Mock GitHub API
+    let gh_server = MockServer::start().await;
+    let gh_body = serde_json::json!({
+        "advisories": [{
+            "ghsa_id": "GHSA-xxxx-xxxx",
+            "cve_id": "CVE-2023-11111",
+            "summary": "GH vuln",
+            "severity": "HIGH",
+            "cvss_score": 7.5,
+            "references": ["http://example.com/gh"],
+            "cwes": ["CWE-79"],
+            "published_at": "2023-12-25T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z"
+        }]
+    });
+    Mock::given(method("GET")).and(path("/advisories"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(gh_body))
+        .mount(&gh_server)
+        .await;
+
+    // Infrastructure setup
+    let db_file = NamedTempFile::new()?;
+    let db_config = DatabaseConfig {
+        url: format!("sqlite://{}", db_file.path().display()),
+        max_connections: 1,
+        connection_timeout: 30,
+        enable_wal: false,
+    };
+    let database = DatabaseManager::new(&db_config).await?;
+    let cache_config = CacheConfig {
+        enable_memory: true,
+        enable_disk: false,
+        memory_max_entries: 100,
+        disk_cache_dir: None,
+        default_ttl: std::time::Duration::from_secs(3600),
+        cleanup_interval: std::time::Duration::from_secs(3600),
+    };
+    let cache = Cache::new(cache_config)?;
+    let rate_limiter = RateLimiterFactory::create_default_multi_limiter().await?;
+
+    let vuln_db = VulnerabilityDatabase::new(
+        database.clone(),
+        cache.clone(),
+        rate_limiter,
+        NvdConfig { base_url: nvd_server.uri(), api_key: None, enabled: true },
+        OsvConfig { base_url: osv_server.uri(), enabled: true },
+        GitHubConfig { base_url: gh_server.uri(), token: None, enabled: true },
+    ).await?;
+
+    // First call performs API requests
+    let vulns = vuln_db.check_package_vulnerabilities("example", Some("1.0.0"), "npm").await?;
+    assert_eq!(vulns.len(), 1);
+    assert_eq!(vulns[0].cve_id, "CVE-2023-11111");
+
+    let stored = database.get_vulnerabilities_for_package("example").await?;
+    assert_eq!(stored.len(), 1);
+
+    // Second call should use cache (no extra HTTP requests)
+    let _ = vuln_db.check_package_vulnerabilities("example", Some("1.0.0"), "npm").await?;
+    assert_eq!(osv_server.received_requests().await.unwrap().len(), 1);
+    assert_eq!(nvd_server.received_requests().await.unwrap().len(), 1);
+    assert_eq!(gh_server.received_requests().await.unwrap().len(), 1);
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- enable GitHub Security Advisory lookups in `VulnerabilityDatabase`
- support reserved column name by quoting `references`
- add integration test for vulnerability DB API and caching

## Testing
- `cargo test --test security_vuln_db -- --nocapture`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849fd6c3a08832486df18dfba3f4e3f