### PR TITLE
Add symbol visibility and CLI listing

### DIFF
--- a/examples/analyze_codebase.rs
+++ b/examples/analyze_codebase.rs
@@ -87,9 +87,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if !file_info.symbols.is_empty() {
             println!("   Symbols found: {}", file_info.symbols.len());
             for symbol in &file_info.symbols {
-                let visibility = if symbol.is_public { "pub" } else { "priv" };
-                println!("     - {} {} '{}' at line {}", 
-                    visibility, symbol.kind, symbol.name, symbol.start_line);
+                println!("     - {} {} '{}' at line {}",
+                    symbol.visibility, symbol.kind, symbol.name, symbol.start_line);
             }
         }
         println!();
@@ -104,7 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for file_info in &result.files {
         for symbol in &file_info.symbols {
             *symbol_counts.entry(symbol.kind.clone()).or_insert(0) += 1;
-            if symbol.is_public {
+            if symbol.visibility == "public" {
                 public_symbols += 1;
             } else {
                 private_symbols += 1;

--- a/src/advanced_ai_analysis.rs
+++ b/src/advanced_ai_analysis.rs
@@ -1326,7 +1326,7 @@ impl AdvancedAIAnalyzer {
 
                 if symbol.kind == "function" {
                     total_functions += 1;
-                    if symbol.is_public {
+                    if symbol.visibility == "public" {
                         public_functions += 1;
                     }
                     total_function_lines +=
@@ -1667,7 +1667,7 @@ impl AdvancedAIAnalyzer {
 
             // Generate function documentation for public functions
             for symbol in &file.symbols {
-                if symbol.kind == "function" && symbol.is_public {
+                if symbol.kind == "function" && symbol.visibility == "public" {
                     insights.push(DocumentationInsight {
                         insight_type: InsightType::FunctionDoc,
                         target: format!("{}::{}", file.path.display(), symbol.name),

--- a/src/ai_analysis.rs
+++ b/src/ai_analysis.rs
@@ -248,7 +248,7 @@ impl AIAnalyzer {
         let total_symbols: usize = result.files.iter().map(|f| f.symbols.len()).sum();
         let _public_symbols: usize = result.files.iter()
             .flat_map(|f| &f.symbols)
-            .filter(|s| s.is_public)
+            .filter(|s| s.visibility == "public")
             .count();
 
         let complexity_level = self.assess_codebase_complexity(result);
@@ -503,7 +503,7 @@ impl AIAnalyzer {
                 if symbol.name == "main" && symbol.kind == "function" {
                     entry_points.push(format!("{}::{}", file.path.display(), symbol.name));
                 }
-                if symbol.is_public && (symbol.kind == "function" || symbol.kind == "struct" || symbol.kind == "class") {
+                if symbol.visibility == "public" && (symbol.kind == "function" || symbol.kind == "struct" || symbol.kind == "class") {
                     if symbol.name.contains("new") || symbol.name.contains("create") || symbol.name.contains("init") {
                         entry_points.push(format!("{}::{}", file.path.display(), symbol.name));
                     }
@@ -680,7 +680,7 @@ impl AIAnalyzer {
     }
 
     fn determine_file_role(&self, file: &FileInfo, _file_name: &str) -> String {
-        let public_symbols = file.symbols.iter().filter(|s| s.is_public).count();
+        let public_symbols = file.symbols.iter().filter(|s| s.visibility == "public").count();
         let total_symbols = file.symbols.len();
 
         if public_symbols > total_symbols / 2 {
@@ -704,7 +704,7 @@ impl AIAnalyzer {
             responsibilities.push(format!("Defines {} {}(s)", count, symbol_type));
         }
 
-        if file.symbols.iter().any(|s| s.is_public) {
+        if file.symbols.iter().any(|s| s.visibility == "public") {
             responsibilities.push("Provides public API".to_string());
         }
 
@@ -739,7 +739,7 @@ impl AIAnalyzer {
             suggestions.push("High symbol count - consider grouping related functionality".to_string());
         }
 
-        if file.symbols.iter().filter(|s| s.is_public).count() > 10 {
+        if file.symbols.iter().filter(|s| s.visibility == "public").count() > 10 {
             suggestions.push("Large public API - consider reducing surface area".to_string());
         }
 
@@ -768,9 +768,9 @@ impl AIAnalyzer {
 
     fn generate_symbol_usage(&self, symbol: &Symbol) -> String {
         match symbol.kind.as_str() {
-            "function" if symbol.is_public => format!("Call {}() to use this functionality", symbol.name),
-            "struct" if symbol.is_public => format!("Create instances using {}::new() or similar", symbol.name),
-            "enum" if symbol.is_public => format!("Use {}::VariantName to access enum values", symbol.name),
+            "function" if symbol.visibility == "public" => format!("Call {}() to use this functionality", symbol.name),
+            "struct" if symbol.visibility == "public" => format!("Create instances using {}::new() or similar", symbol.name),
+            "enum" if symbol.visibility == "public" => format!("Use {}::VariantName to access enum values", symbol.name),
             _ => "Internal implementation detail".to_string(),
         }
     }
@@ -791,7 +791,7 @@ impl AIAnalyzer {
     fn suggest_symbol_best_practices(&self, symbol: &Symbol) -> Vec<String> {
         let mut practices = Vec::new();
 
-        if symbol.is_public {
+        if symbol.visibility == "public" {
             practices.push("Add comprehensive documentation for public APIs".to_string());
             practices.push("Consider adding usage examples".to_string());
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -124,6 +124,17 @@ enum Commands {
         #[arg(long)]
         public_only: bool,
     },
+
+    /// List all symbols grouped by file
+    Symbols {
+        /// Directory to analyze
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+
+        /// Output format (table or json)
+        #[arg(short, long, default_value = "table")]
+        format: String,
+    },
     
     /// Show supported languages and their capabilities
     Languages,
@@ -370,6 +381,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Find { path, name, symbol_type, language, public_only } => {
             find_command(path, name, symbol_type, language, public_only)?;
         }
+        Commands::Symbols { path, format } => {
+            symbols_command(path, format)?;
+        }
         Commands::Languages => {
             languages_command()?;
         }
@@ -496,7 +510,7 @@ fn print_summary(result: &rust_tree_sitter::AnalysisResult) {
     let total_symbols: usize = result.files.iter().map(|f| f.symbols.len()).sum();
     let public_symbols: usize = result.files.iter()
         .flat_map(|f| &f.symbols)
-        .filter(|s| s.is_public)
+        .filter(|s| s.visibility == "public")
         .count();
     
     println!("\n{}", "🔧 SYMBOLS".bright_cyan().bold());
@@ -533,7 +547,7 @@ fn print_analysis_table(result: &rust_tree_sitter::AnalysisResult, detailed: boo
                     kind: symbol.kind.clone(),
                     file: file.path.display().to_string(),
                     line: symbol.start_line,
-                    visibility: if symbol.is_public { "public".to_string() } else { "private".to_string() },
+                    visibility: symbol.visibility.clone(),
                 })
             })
             .collect();
@@ -760,7 +774,7 @@ fn find_command(
 
         for symbol in &file.symbols {
             // Filter by visibility
-            if public_only && !symbol.is_public {
+            if public_only && symbol.visibility != "public" {
                 continue;
             }
 
@@ -783,7 +797,7 @@ fn find_command(
                 kind: symbol.kind.clone(),
                 file: file.path.display().to_string(),
                 line: symbol.start_line,
-                visibility: if symbol.is_public { "public".to_string() } else { "private".to_string() },
+                visibility: symbol.visibility.clone(),
             });
         }
     }
@@ -802,6 +816,47 @@ fn find_command(
     Ok(())
 }
 
+fn symbols_command(path: PathBuf, format: String) -> Result<(), Box<dyn std::error::Error>> {
+    let mut analyzer = CodebaseAnalyzer::new();
+    let result = analyzer.analyze_directory(&path)?;
+
+    match format.as_str() {
+        "json" => {
+            let mut files = serde_json::Map::new();
+            for file in &result.files {
+                if file.symbols.is_empty() { continue; }
+                let symbols: Vec<_> = file.symbols.iter().map(|s| {
+                    serde_json::json!({
+                        "name": s.name,
+                        "kind": s.kind,
+                        "line": s.start_line,
+                        "visibility": s.visibility,
+                        "documentation": s.documentation,
+                    })
+                }).collect();
+                files.insert(file.path.display().to_string(), serde_json::Value::Array(symbols));
+            }
+            println!("{}", serde_json::to_string_pretty(&serde_json::Value::Object(files))?);
+        }
+        _ => {
+            for file in &result.files {
+                if file.symbols.is_empty() { continue; }
+                println!("\n📄 {}", file.path.display());
+                let rows: Vec<SymbolRow> = file.symbols.iter().map(|s| SymbolRow {
+                    name: s.name.clone(),
+                    kind: s.kind.clone(),
+                    file: file.path.display().to_string(),
+                    line: s.start_line,
+                    visibility: s.visibility.clone(),
+                }).collect();
+                let table = Table::new(rows);
+                println!("{}", table);
+            }
+        }
+    }
+
+    Ok(())
+}
 fn languages_command() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "🌐 SUPPORTED LANGUAGES".bright_cyan().bold());
     println!("{}", "=".repeat(60).bright_cyan());
@@ -927,7 +982,7 @@ fn interactive_find(result: &rust_tree_sitter::AnalysisResult, pattern: &str) {
     println!("{}", format!("Found {} symbols matching '{}':", found.len(), pattern).bright_green());
     for (file, symbol) in found.iter().take(20) {
         println!("  {} {} in {} (line {})",
-            if symbol.is_public { "pub".bright_green() } else { "prv".bright_yellow() },
+            if symbol.visibility == "public" { "pub".bright_green() } else { "prv".bright_yellow() },
             format!("{} {}", symbol.kind, symbol.name).bright_white(),
             file.path.display().to_string().bright_blue(),
             symbol.start_line.to_string().bright_cyan()
@@ -1061,7 +1116,7 @@ fn generate_insights(result: &rust_tree_sitter::AnalysisResult, _focus: &str) ->
     let total_symbols: usize = result.files.iter().map(|f| f.symbols.len()).sum();
     let public_symbols: usize = result.files.iter()
         .flat_map(|f| &f.symbols)
-        .filter(|s| s.is_public)
+        .filter(|s| s.visibility == "public")
         .count();
 
     let primary_language = result.languages.iter()
@@ -1777,7 +1832,7 @@ fn generate_symbol_map_text(files: &[&rust_tree_sitter::FileInfo]) -> Result<(),
             sorted_symbols.sort_by(|a, b| a.start_line.cmp(&b.start_line));
 
             for symbol in sorted_symbols.iter().take(10) { // Limit to 10 per file
-                let visibility = if symbol.is_public { "pub".bright_green() } else { "prv".bright_yellow() };
+                let visibility = if symbol.visibility == "public" { "pub".bright_green() } else { "prv".bright_yellow() };
                 println!("    {} {} {} (line {})",
                     "•".bright_black(),
                     visibility,
@@ -1918,7 +1973,7 @@ fn create_symbol_summary_json(files: &[&rust_tree_sitter::FileInfo]) -> serde_js
     for file in files {
         for symbol in &file.symbols {
             *symbol_counts.entry(symbol.kind.clone()).or_insert(0) += 1;
-            if symbol.is_public {
+            if symbol.visibility == "public" {
                 *public_counts.entry(symbol.kind.clone()).or_insert(0) += 1;
             }
         }
@@ -1941,7 +1996,8 @@ fn create_symbol_map_json(files: &[&rust_tree_sitter::FileInfo]) -> serde_json::
                 "kind": s.kind,
                 "line": s.start_line,
                 "column": s.start_column,
-                "public": s.is_public
+                "visibility": s.visibility,
+                "documentation": s.documentation
             })
         }).collect();
 

--- a/src/test_coverage.rs
+++ b/src/test_coverage.rs
@@ -702,7 +702,7 @@ impl TestCoverageAnalyzer {
     /// Estimate coverage for a single file
     fn estimate_file_coverage(&self, file: &FileInfo, test_files: &[&FileInfo]) -> Result<FileCoverage> {
         let total_functions = file.symbols.iter()
-            .filter(|s| s.kind == "function" && s.is_public)
+            .filter(|s| s.kind == "function" && s.visibility == "public")
             .count();
 
         // Simple heuristic: look for test functions that might test this file
@@ -763,7 +763,7 @@ impl TestCoverageAnalyzer {
         for file in &analysis_result.files {
             if !self.is_test_file(file) {
                 for symbol in &file.symbols {
-                    if symbol.kind == "function" && symbol.is_public {
+                    if symbol.kind == "function" && symbol.visibility == "public" {
                         // Check if this function has tests
                         let has_test = self.function_has_test(symbol, file, test_files);
 
@@ -774,7 +774,7 @@ impl TestCoverageAnalyzer {
                             missing_tests.push(MissingTest {
                                 function_name: symbol.name.clone(),
                                 file: file.path.clone(),
-                                visibility: if symbol.is_public { FunctionVisibility::Public } else { FunctionVisibility::Private },
+                                visibility: if symbol.visibility == "public" { FunctionVisibility::Public } else { FunctionVisibility::Private },
                                 complexity,
                                 priority,
                                 suggested_tests: vec![TestType::Unit],
@@ -810,7 +810,7 @@ impl TestCoverageAnalyzer {
 
     /// Determine test priority for a function
     fn determine_test_priority(&self, symbol: &crate::Symbol, complexity: &FunctionComplexity) -> TestPriority {
-        if symbol.is_public {
+        if symbol.visibility == "public" {
             match complexity {
                 FunctionComplexity::VeryHigh => TestPriority::Critical,
                 FunctionComplexity::High => TestPriority::High,
@@ -1055,7 +1055,7 @@ impl TestCoverageAnalyzer {
         analysis_result.files.iter()
             .filter(|file| !self.is_test_file(file))
             .flat_map(|file| &file.symbols)
-            .filter(|symbol| symbol.kind == "function" && symbol.is_public)
+            .filter(|symbol| symbol.kind == "function" && symbol.visibility == "public")
             .count()
     }
 

--- a/tests/symbols_cli.rs
+++ b/tests/symbols_cli.rs
@@ -1,0 +1,14 @@
+use assert_cmd::Command;
+use serde_json::Value;
+
+#[test]
+fn cli_symbols_json() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::cargo_bin("tree-sitter-cli")?
+        .args(["symbols", "test_files", "--format", "json"])
+        .output()?;
+    assert!(output.status.success());
+    let data = String::from_utf8(output.stdout)?;
+    let json: Value = serde_json::from_str(&data)?;
+    assert!(json.as_object().unwrap().len() > 0);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- track symbol visibility string and optional documentation
- implement `symbols` subcommand for listing symbols by file
- update analyzer unit test to check symbol docs and visibility
- add CLI integration test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684a0b68d75c8324a07824977f9f03d3