### PR TITLE
feat(cli+deps): TASK_LIST, --enable-security, SBOM, OSV scaffold

### DIFF
--- a/TASK_LIST.md
+++ b/TASK_LIST.md
@@ -1,0 +1,56 @@
+# Roadmap and Task List
+
+This roadmap organizes high‑impact features into pragmatic releases with owners and CI gates. Each task is small, testable, and reversible. Default style is Pure TDD and FP per INSTRUCTIONS.md.
+
+## Release R1: Output + Dependencies + Security Baseline (2–3 weeks)
+
+- SARIF polish: validate schema, add rule metadata, stable IDs. Owner: CLI. CI: sarif_output_tests.
+- PR annotations: GitHub review comments via SARIF + annotations. Owner: CLI. CI: e2e smoke on PR.
+- Dependency scanning v2: OSV/CVE lookup scaffold + CycloneDX SBOM generation. Owner: deps. CI: dependency_analysis_unit_tests.
+- JS import detection v2: scoped packages, side-effect imports, export-from (Done), add test coverage for edge cases. Owner: deps. CI: tests.
+- Minimal schema validations for manifests (Done): cargo/package.json error messages. Owner: deps. CI: tests.
+- CLI flags: include-dev (Done), enable-security (Analyze/Security). Owner: CLI. CI: cli_determinism.
+
+## Release R2: Performance + Watch Mode (2 weeks)
+
+- Incremental cache: hash-based file cache + AST reuse. Owner: core. CI: performance_optimization_tests.
+- Watch mode: file watcher + incremental analyze; debounced. Owner: CLI. CI: e2e smoke.
+- Parallelism controls: adaptive threads + cancellation. Owner: core. CI: perf benches.
+
+## Release R3: Security Depth (3–4 weeks)
+
+- Taint tracking v1: sources/sinks/sanitizers for Rust/JS/Python. Owner: sec. CI: taint unit tests.
+- Secrets scanning v2: curated patterns + entropy tuning + suppressions. Owner: sec. CI: secrets_detector.
+- License policy: SPDX detection + policy-as-code (allow/deny). Owner: compliance. CI: policy tests.
+
+## Release R4: IDE/LSP + Auto-Fix (4–6 weeks)
+
+- LSP server: diagnostics + code actions + quick-fix. Owner: IDE. CI: protocol tests.
+- Auto-fixes v1: safe transforms for common issues (innerHTML→textContent, shell→argv, read_to_string validation). Owner: refactor. CI: transformation tests.
+
+## Release R5: Policy Platform + Dashboards (4 weeks)
+
+- Policy engine: YAML/TOML rules, repo overrides, CI gates. Owner: platform. CI: policy e2e.
+- Dashboard: basic TUI/Web summary (trends, hotspots). Owner: platform. CI: snapshot tests.
+
+---
+
+## Active TODOs (Short Term)
+
+1. Add `--enable-security` flag to `analyze` and `security` commands; wire to `AnalysisConfig`. [Owner: CLI]
+2. Add OSV/CVE lookup scaffold (no network calls yet) with typed results and stubs. [Owner: deps]
+3. Add CycloneDX SBOM serializer for `DependencyAnalysisResult`. [Owner: deps]
+4. Add watch mode scaffold (`tree-sitter-cli watch`) with no-op scan loop. [Owner: CLI]
+
+## CI Gates
+
+- All: `cargo fmt --check`, `clippy -D warnings`, `cargo test`.
+- SARIF: schema shape test(s) must pass.
+- Perf: `performance_optimization_tests` under threshold.
+- Security: no panics; baseline tests pass.
+
+## Notes
+
+- Keep new modules feature-gated (`ml`, `net`, `db`) to preserve fast default builds.
+- Favor pure functions and immutable data; isolate IO at boundaries.
+

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -21,6 +21,7 @@ pub fn execute(
     output: Option<&PathBuf>,
     detailed: bool,
     threads: Option<usize>,
+    enable_security: bool,
 ) -> CliResult<()> {
     // Validate inputs
     validate_path(path)?;
@@ -43,6 +44,7 @@ pub fn execute(
         exclude_dirs.cloned(),
         include_exts.cloned(),
         threads,
+        enable_security,
     )?;
     
     let mut analyzer = CodebaseAnalyzer::with_config(config)

--- a/src/cli/commands/dependencies.rs
+++ b/src/cli/commands/dependencies.rs
@@ -87,6 +87,17 @@ pub fn execute(
             }
         }
     }
+
+    // Optional SBOM emission if path ends with .sbom.json
+    if let Some(output_path) = output {
+        if let Some(file) = output_path.file_name().and_then(|n| n.to_str()) {
+            if file.ends_with(".sbom.json") {
+                let sbom = crate::cli::sbom::to_cyclonedx(&dependency_result);
+                std::fs::write(output_path, sbom)?;
+                print_success(&format!("SBOM saved to {}", output_path.display()));
+            }
+        }
+    }
     
     Ok(())
 }

--- a/src/cli/commands/dependencies.rs
+++ b/src/cli/commands/dependencies.rs
@@ -32,7 +32,7 @@ pub fn execute(
     let pb = create_progress_bar("Analyzing dependencies...");
     
     // Configure analyzer
-    let config = create_analysis_config(1024, 20, "full", false, None, None, None)?;
+    let config = create_analysis_config(1024, 20, "full", false, None, None, None, false)?;
     let mut analyzer = CodebaseAnalyzer::with_config(config)
         .map_err(|e| CliError::Dependencies(e.to_string()))?;
     

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -26,7 +26,7 @@ impl Execute for Commands {
         match self {
             Commands::Analyze {
                 path, format, max_size, max_depth, depth, include_hidden,
-                exclude_dirs, include_exts, output, detailed, threads, print_schema, schema_version
+                exclude_dirs, include_exts, output, detailed, threads, enable_security, print_schema, schema_version
             } => {
                 if *print_schema {
                     // Currently only v1 is supported
@@ -42,7 +42,7 @@ impl Execute for Commands {
                 }
                 analyze::execute(
                     path, format, *max_size, *max_depth, depth, *include_hidden,
-                    exclude_dirs.as_ref(), include_exts.as_ref(), output.as_ref(), *detailed, *threads
+                    exclude_dirs.as_ref(), include_exts.as_ref(), output.as_ref(), *detailed, *threads, *enable_security
                 )
             }
             Commands::Query { path, pattern, language, prefilter, context, format } => {
@@ -88,7 +88,7 @@ impl Execute for Commands {
                 explain::execute(path, file.as_ref(), symbol.as_ref(), format, *detailed, *learning)
             }
             Commands::Security {
-                path, format, min_severity, output, summary_only, compliance, depth, print_schema, schema_version
+                path, format, min_severity, output, summary_only, compliance, depth, print_schema, schema_version, enable_security
             } => {
                 if *print_schema {
                     match schema_version.as_str() {
@@ -100,7 +100,7 @@ impl Execute for Commands {
                     }
                 }
                 security::execute(
-                    path, format, min_severity, output.as_ref(), *summary_only, *compliance, depth
+                    path, format, min_severity, output.as_ref(), *summary_only, *compliance, depth, *enable_security
                 )
             }
             Commands::Refactor {

--- a/src/cli/commands/refactor.rs
+++ b/src/cli/commands/refactor.rs
@@ -31,7 +31,7 @@ pub fn execute(
     let pb = create_progress_bar("Analyzing code for refactoring opportunities...");
     
     // Configure analyzer
-    let config = create_analysis_config(1024, 20, "full", false, None, None, None)?;
+    let config = create_analysis_config(1024, 20, "full", false, None, None, None, false)?;
     let mut analyzer = CodebaseAnalyzer::with_config(config)
         .map_err(|e| CliError::Refactoring(e.to_string()))?;
     

--- a/src/cli/commands/security.rs
+++ b/src/cli/commands/security.rs
@@ -18,6 +18,8 @@ pub fn execute(
     summary_only: bool,
     compliance: bool,
     depth: &str,
+    // Whether to enable heavy security scanning during initial parsing
+    enable_security: bool,
 ) -> CliResult<()> {
     // Validate inputs
     validate_path(path)?;
@@ -32,7 +34,7 @@ pub fn execute(
     let pb = create_progress_bar("Running security scan...");
     
     // Configure analyzer
-    let config = create_analysis_config(1024, 20, depth, false, None, None, None)?;
+    let config = create_analysis_config(1024, 20, depth, false, None, None, None, enable_security)?;
     let mut analyzer = CodebaseAnalyzer::with_config(config)
         .map_err(|e| CliError::Security(e.to_string()))?;
     

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,6 +72,10 @@ pub enum Commands {
         #[arg(long)]
         threads: Option<usize>,
 
+        /// Enable heavy security scanning during analysis
+        #[arg(long, default_value_t = false)]
+        enable_security: bool,
+
         /// Print JSON schema and exit
         #[arg(long, default_value_t = false)]
         print_schema: bool,
@@ -289,6 +293,10 @@ pub enum Commands {
         /// Schema version to print
         #[arg(long, default_value = "1")]
         schema_version: String,
+        
+        /// Enable heavy security scanning during initial analysis (rarely needed)
+        #[arg(long, default_value_t = false)]
+        enable_security: bool,
     },
 
     /// Smart refactoring suggestions

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod output;
 pub mod utils;
 pub mod schemas;
 pub mod sarif;
+pub mod sbom;
 
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;

--- a/src/cli/sbom.rs
+++ b/src/cli/sbom.rs
@@ -1,0 +1,42 @@
+//! CycloneDX SBOM serializer (minimal JSON)
+//! Converts DependencyAnalysisResult into a CycloneDX-like JSON structure.
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Bom<'a> {
+    #[serde(rename = "bomFormat")] bom_format: &'static str,
+    #[serde(rename = "specVersion")] spec_version: &'static str,
+    version: u32,
+    components: Vec<Component<'a>>,
+}
+
+#[derive(Serialize)]
+struct Component<'a> {
+    #[serde(rename = "type")] ctype: &'static str,
+    name: &'a str,
+    version: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")] purl: Option<String>,
+}
+
+fn purl_for(manager: &crate::dependency_analysis::PackageManager, name: &str, version: &str) -> Option<String> {
+    match manager {
+        crate::dependency_analysis::PackageManager::Cargo => Some(format!("pkg:cargo/{name}@{version}")),
+        crate::dependency_analysis::PackageManager::Npm | crate::dependency_analysis::PackageManager::Yarn => Some(format!("pkg:npm/{name}@{version}")),
+        crate::dependency_analysis::PackageManager::Pip | crate::dependency_analysis::PackageManager::Poetry | crate::dependency_analysis::PackageManager::Pipenv => Some(format!("pkg:pypi/{name}@{version}")),
+        crate::dependency_analysis::PackageManager::GoMod => Some(format!("pkg:golang/{name}@{version}")),
+    }
+}
+
+pub fn to_cyclonedx(deps: &'_ crate::DependencyAnalysisResult) -> String {
+    let components: Vec<_> = deps.dependencies.iter().map(|d| Component {
+        ctype: "library",
+        name: d.name.as_str(),
+        version: d.version.as_str(),
+        purl: purl_for(&d.manager, &d.name, &d.version),
+    }).collect();
+
+    let bom = Bom { bom_format: "CycloneDX", spec_version: "1.4", version: 1, components };
+    serde_json::to_string_pretty(&bom).unwrap_or_else(|_| "{}".to_string())
+}
+

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -29,6 +29,7 @@ pub fn create_analysis_config(
     exclude_dirs: Option<String>,
     include_exts: Option<String>,
     threads: Option<usize>,
+    enable_security: bool,
 ) -> CliResult<AnalysisConfig> {
     let mut config = AnalysisConfig::default();
     
@@ -63,6 +64,8 @@ pub fn create_analysis_config(
 
     // Apply thread count if provided
     config.thread_count = threads;
+    // Enable or disable heavy security scanning
+    config.enable_security = enable_security;
     
     Ok(config)
 }


### PR DESCRIPTION
This PR builds on prior work with:\n\n- TASK_LIST.md: multi-release roadmap with owners/CI gates.\n- --enable-security flag: analyze/security now toggle AnalysisConfig.enable_security.\n- SBOM support: minimal CycloneDX JSON serializer; emit when output path ends with .sbom.json.\n- VulnerabilityProvider scaffold for future OSV/CVE integration.\n\nIncludes fixes to dependency analysis tests, security tests writing real files, and retains performance defaults (security scans disabled unless enabled).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional CycloneDX SBOM export: specify an output filename ending with .sbom.json to generate an SBOM after dependency analysis.
  - New CLI flag --enable_security for Analyze and Security commands to toggle deeper security scanning.
- Documentation
  - Added a Roadmap and Task List detailing upcoming releases, CI gates, and active TODOs.

No breaking changes; existing workflows continue to work without enabling new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->